### PR TITLE
feat: add AVPlayerLayer convenience methods

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/mux-stats-sdk-avplayer",
       "state" : {
-        "revision" : "7b0e6e2eda1298e145264c5c4e8663d0f8e807d3",
-        "version" : "3.3.1"
+        "revision" : "5a310713d8330cb2c8e4755d9a80088697536d65",
+        "version" : "3.3.2"
       }
     },
     {

--- a/Sources/MuxAVPlayerSDK/Monitoring/Monitor.swift
+++ b/Sources/MuxAVPlayerSDK/Monitoring/Monitor.swift
@@ -79,9 +79,78 @@ class Monitor {
         bindings[objectIdentifier] = monitoredPlayer
     }
 
+    func setupMonitoring(
+        playerLayer: AVPlayerLayer,
+        options: MonitoringOptions
+    ) {
+        let monitoredPlayer: MonitoredPlayer
+
+        if let customerData = options.customerData {
+
+            let binding = MUXSDKStats.monitorAVPlayerLayer(
+                playerLayer,
+                withPlayerName: options.playerName,
+                customerData: customerData
+            )
+
+            monitoredPlayer = MonitoredPlayer(
+                name: options.playerName,
+                binding: binding!
+            )
+
+        } else {
+
+            let customerData = MUXSDKCustomerData()
+
+            if let environmentKey = options.environmentKey {
+                let customerPlayerData = MUXSDKCustomerPlayerData()
+                customerPlayerData.environmentKey = environmentKey
+                customerData.customerPlayerData = customerPlayerData
+            }
+
+            let binding = MUXSDKStats.monitorAVPlayerLayer(
+                playerLayer,
+                withPlayerName: options.playerName,
+                customerData: customerData
+            )
+
+            monitoredPlayer = MonitoredPlayer(
+                name: options.playerName,
+                binding: binding!
+            )
+        }
+
+        let playerData = MUXSDKPlayerData()
+        playerData.playerSoftwareVersion = SemanticVersion.versionString
+        playerData.playerSoftwareName = "MuxAVPlayerLayer"
+
+        let playbackEvent = MUXSDKPlaybackEvent()
+        playbackEvent.playerData = playerData
+
+        MUXSDKCore.dispatchEvent(
+            playbackEvent,
+            forPlayer: options.playerName
+        )
+
+        let objectIdentifier = ObjectIdentifier(playerLayer)
+
+        bindings[objectIdentifier] = monitoredPlayer
+    }
+
     func tearDownMonitoring(playerViewController: AVPlayerViewController) {
 
         let objectIdentifier = ObjectIdentifier(playerViewController)
+
+        guard let playerName = bindings[objectIdentifier]?.name else { return }
+
+        MUXSDKStats.destroyPlayer(playerName)
+
+        bindings.removeValue(forKey: objectIdentifier)
+    }
+
+    func tearDownMonitoring(playerLayer: AVPlayerLayer) {
+
+        let objectIdentifier = ObjectIdentifier(playerLayer)
 
         guard let playerName = bindings[objectIdentifier]?.name else { return }
 

--- a/Sources/MuxAVPlayerSDK/PublicAPI/Extensions/AVPlayerLayer+Mux.swift
+++ b/Sources/MuxAVPlayerSDK/PublicAPI/Extensions/AVPlayerLayer+Mux.swift
@@ -101,4 +101,126 @@ extension AVPlayerLayer {
         Monitor.shared.tearDownMonitoring(playerLayer: self)
     }
     
+
+    /// Prepares an already instantiated AVPlayerLayer
+    /// for playback.
+    ///
+    /// If no AVPlayerLayer doesn't hold an AVPlayer reference,
+    /// this method will create one and set the AVPlayerLayer
+    /// player property. If the AVPlayerLayer already holds
+    /// a player, it will be configured for playback.
+    ///
+    ///   - playbackID: playback ID of the Mux Asset
+    ///   you'd like to play
+    public func prepare(
+        playbackID: String
+    ) {
+        prepare(
+            playerItem: AVPlayerItem(
+                playbackID: playbackID
+            ),
+            monitoringOptions: MonitoringOptions(
+                playbackID: playbackID
+            )
+        )
+    }
+
+    /// Prepares an already instantiated AVPlayerLayer
+    /// for playback.
+    ///
+    /// If no AVPlayerLayer doesn't hold an AVPlayer reference,
+    /// this method will create one and set the AVPlayerLayer
+    /// player property. If the AVPlayerLayer already holds
+    /// a player, it will be configured for playback.
+    /// - Parameters:
+    ///   - playbackID: playback ID of the Mux Asset
+    ///   you'd like to play
+    ///   - playbackOptions: playback-related options such
+    ///   as custom domain and maximum resolution
+    public func prepare(
+        playbackID: String,
+        playbackOptions: PlaybackOptions
+    ) {
+        prepare(
+            playerItem: AVPlayerItem(
+                playbackID: playbackID,
+                playbackOptions: playbackOptions
+            ),
+            monitoringOptions: MonitoringOptions(
+                playbackID: playbackID
+            )
+        )
+    }
+
+    /// Prepares an already instantiated AVPlayerLayer
+    /// for playback.
+    ///
+    /// If no AVPlayerLayer doesn't hold an AVPlayer reference,
+    /// this method will create one and set the AVPlayerLayer
+    /// player property. If the AVPlayerLayer already holds
+    /// a player, it will be configured for playback.
+    /// - Parameters:
+    ///   - playbackID: playback ID of the Mux Asset
+    ///   you'd like to play
+    ///   - monitoringOptions: Options to customize monitoring
+    ///   data reported by Mux
+    public func prepare(
+        playbackID: String,
+        monitoringOptions: MonitoringOptions
+    ) {
+        prepare(
+            playerItem: AVPlayerItem(
+                playbackID: playbackID
+            ),
+            monitoringOptions: monitoringOptions
+        )
+    }
+
+    /// Prepares an already instantiated AVPlayerLayer
+    /// for playback.
+    ///
+    /// If no AVPlayerLayer doesn't hold an AVPlayer reference,
+    /// this method will create one and set the AVPlayerLayer
+    /// player property. If the AVPlayerLayer already holds
+    /// a player, it will be configured for playback.
+    /// - Parameters:
+    ///   - playbackID: playback ID of the Mux Asset
+    ///   you'd like to play
+    ///   - playbackOptions: playback-related options such
+    ///   as custom domain and maximum resolution
+    ///   - monitoringOptions: Options to customize monitoring
+    ///   data reported by Mux
+    public func prepare(
+        playbackID: String,
+        playbackOptions: PlaybackOptions,
+        monitoringOptions: MonitoringOptions
+    ) {
+        prepare(
+            playerItem: AVPlayerItem(
+                playbackID: playbackID,
+                playbackOptions: playbackOptions
+            ),
+            monitoringOptions: monitoringOptions
+        )
+    }
+
+    internal func prepare(
+        playerItem: AVPlayerItem,
+        monitoringOptions: MonitoringOptions
+    ) {
+        if let player {
+            player.replaceCurrentItem(
+                with: playerItem
+            )
+        } else {
+            player = AVPlayer(
+                playerItem: playerItem
+            )
+        }
+
+        Monitor.shared.setupMonitoring(
+            playerLayer: self,
+            options: monitoringOptions
+        )
+    }
 }

--- a/Sources/MuxAVPlayerSDK/PublicAPI/Extensions/AVPlayerLayer+Mux.swift
+++ b/Sources/MuxAVPlayerSDK/PublicAPI/Extensions/AVPlayerLayer+Mux.swift
@@ -1,0 +1,104 @@
+//
+//  AVPlayerLayer+Mux.swift
+//
+
+import AVFoundation
+import Foundation
+
+extension AVPlayerLayer {
+
+    /// Initializes an AVPlayerLayer that's configured
+    /// to play your Mux Asset as well as monitor and report
+    /// back it's playback performance.
+    /// - Parameter playbackID: playback ID of the Mux
+    /// Asset you'd like to play
+    public convenience init(playbackID: String) {
+        self.init()
+
+        let playerItem = AVPlayerItem(playbackID: playbackID)
+
+        let player = AVPlayer(playerItem: playerItem)
+
+        self.player = player
+
+        let monitoringOptions = MonitoringOptions(
+            playbackID: playbackID
+        )
+
+        Monitor.shared.setupMonitoring(
+            playerLayer: self,
+            options: monitoringOptions
+        )
+    }
+
+    /// Initializes an AVPlayerLayer that's configured
+    /// to play your Mux Asset as well as monitor and report
+    /// back it's playback performance.
+    /// - Parameters:
+    ///   - playbackID: playback ID of the Mux Asset
+    ///   you'd like to play
+    ///   - playbackOptions: playback-related options such
+    ///   as custom domain and maximum resolution
+    convenience init(
+        playbackID: String,
+        playbackOptions: PlaybackOptions
+    ) {
+        self.init()
+
+        let playerItem = AVPlayerItem(
+            playbackID: playbackID,
+            playbackOptions: playbackOptions
+        )
+
+        let player = AVPlayer(playerItem: playerItem)
+
+        self.player = player
+
+        let monitoringOptions = MonitoringOptions(
+            playbackID: playbackID
+        )
+
+        Monitor.shared.setupMonitoring(
+            playerLayer: self,
+            options: monitoringOptions
+        )
+    }
+
+    /// Initializes an AVPlayerLayer that's configured
+    /// to play your Mux Asset as well as monitor and report
+    /// back it's playback performance.
+    /// - Parameters:
+    ///   - playbackID: playback ID of the Mux Asset
+    ///   you'd like to play
+    ///   - playbackOptions: playback-related options such
+    ///   as custom domain and maximum resolution
+    ///   - monitoringOptions: Options to customize monitoring
+    ///   data reported by Mux
+    convenience init(
+        playbackID: String,
+        playbackOptions: PlaybackOptions,
+        monitoringOptions: MonitoringOptions
+    ) {
+        self.init()
+
+        let playerItem = AVPlayerItem(
+            playbackID: playbackID,
+            playbackOptions: playbackOptions
+        )
+
+        let player = AVPlayer(playerItem: playerItem)
+
+        self.player = player
+
+        Monitor.shared.setupMonitoring(
+            playerLayer: self,
+            options: monitoringOptions
+        )
+    }
+
+    /// Stops monitoring the player
+    public func stopMonitoring() {
+        Monitor.shared.tearDownMonitoring(playerLayer: self)
+    }
+    
+}

--- a/Tests/MuxAVPlayerSDKTests/MonitorTests.swift
+++ b/Tests/MuxAVPlayerSDKTests/MonitorTests.swift
@@ -8,7 +8,27 @@ import XCTest
 
 @testable import MuxAVPlayerSDK
 
+class PlayerLayerBackedView: UIView {
+    override class var layerClass: AnyClass {
+        AVPlayerLayer.self
+    }
+
+    var player: AVPlayer? {
+        get {
+            (layer as? AVPlayerLayer)?.player
+        }
+        set {
+            (layer as? AVPlayerLayer)?.player = newValue
+        }
+    }
+}
+
 class MonitorTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        Monitor.shared.bindings.removeAll()
+    }
 
     func testPlayerViewControllerMonitoringLifecycle() throws {
 
@@ -50,6 +70,32 @@ class MonitorTests: XCTestCase {
             monitor.bindings.isEmpty
         )
 
+    }
+
+    func testExistingPlayerLayerMonitoringLifecycle() throws {
+
+        let playerLayerBackedView = PlayerLayerBackedView()
+
+        let preexistingPlayerLayer = try XCTUnwrap(
+            playerLayerBackedView.layer as? AVPlayerLayer
+        )
+
+        preexistingPlayerLayer.prepare(
+            playbackID: "abc"
+        )
+
+        let monitor = Monitor.shared
+
+        XCTAssertEqual(
+            monitor.bindings.count,
+            1
+        )
+
+        preexistingPlayerLayer.stopMonitoring()
+
+        XCTAssertTrue(
+            monitor.bindings.isEmpty
+        )
     }
 
 }

--- a/Tests/MuxAVPlayerSDKTests/MonitorTests.swift
+++ b/Tests/MuxAVPlayerSDKTests/MonitorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class MonitorTests: XCTestCase {
 
-    func testMonitoringLifecycle() throws {
+    func testPlayerViewControllerMonitoringLifecycle() throws {
 
         let playerViewController = AVPlayerViewController(
             playbackID: "abc"
@@ -24,6 +24,27 @@ class MonitorTests: XCTestCase {
         )
 
         playerViewController.stopMonitoring()
+
+        XCTAssertTrue(
+            monitor.bindings.isEmpty
+        )
+
+    }
+
+    func testPlayerLayerMonitoringLifecycle() throws {
+
+        let playerLayer = AVPlayerLayer(
+            playbackID: "abc"
+        )
+
+        let monitor = Monitor.shared
+
+        XCTAssertEqual(
+            monitor.bindings.count,
+            1
+        )
+
+        playerLayer.stopMonitoring()
 
         XCTAssertTrue(
             monitor.bindings.isEmpty


### PR DESCRIPTION

This PR adds convenience initializers for `AVPlayerLayer` as well as convenience methods that prepare an already initialized `AVPlayerLayer`. 

The latter supports anyone using an `AVPlayerLayer` backed `UIView`. See example in the test suite.
